### PR TITLE
Add Slack features

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
     machine: true
     steps:
       - ghpr/build-prospective-branch
-      - pack-validate
       - ghpr/slack-pr-author:
           message: yay!
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,56 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
-# Use a package of configuration called an orb.
+
 orbs:
-  # Declare a dependency on the welcome-orb
-  welcome: circleci/welcome-orb@0.4.1
-# Orchestrate or schedule a set of jobs
+  # dev version needs to be manually deployed to accurately test commit changes.
+  # Once deployed, update <alpha> to reflect the version deployed.
+  ghpr: narrativescience/ghpr@dev:alpha
+
+commands:
+  pack-validate:
+    description: Pack and validate the orb config
+    steps:
+      - run:
+          name: Pack config
+          command: circleci config pack src > orb.yml
+      - run:
+          name: Valid orb.yml
+          command: circleci orb validate orb.yml
+
+jobs:
+  test:
+    machine: true
+    steps:
+      - ghpr/build-prospective-branch
+      - pack-validate
+      - ghpr/slack-pr-author:
+          message: yay!
+
+  publish:
+    machine: true
+      steps:
+        - pack-validate
+        - run:
+            name: Publish new orb version
+            command: |
+              # TODO figure out how to configure CLI so publishing works
+              circleci orb publish orb.yml "narrativescience/ghpr@$CIRCLE_TAG"
+
 workflows:
-  # Name the workflow "welcome"
-  welcome:
-    # Run the welcome/run job in its own container
+  pull_request:
     jobs:
-      - welcome/run
+      - test:
+          context: opensource
+          filters:
+            branches:
+              ignore:
+                - master
+  # TODO uncomment and make it possible to auto-publish
+  # publish:
+  #   jobs:
+  #     - publish:
+  #         context: opensource
+  #         filters:
+  #           tags:
+  #             only: /v[0-9]+(\.[0-9]+)*/
+  #           branches:
+  #             ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - ghpr/build-prospective-branch
       - ghpr/slack-pr-author:
-          message: yay!
+          message: ":tada: Tests passed!"
 
   publish:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,13 +27,13 @@ jobs:
 
   publish:
     machine: true
-      steps:
-        - pack-validate
-        - run:
-            name: Publish new orb version
-            command: |
-              # TODO figure out how to configure CLI so publishing works
-              circleci orb publish orb.yml "narrativescience/ghpr@$CIRCLE_TAG"
+    steps:
+      - pack-validate
+      - run:
+          name: Publish new orb version
+          command: |
+            # TODO figure out how to configure CLI so publishing works
+            circleci orb publish orb.yml "narrativescience/ghpr@$CIRCLE_TAG"
 
 workflows:
   pull_request:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+orb.yml

--- a/README.md
+++ b/README.md
@@ -1,17 +1,35 @@
-# CircleCI Orb: GitHub PR [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/narrativescience/ghpr)](https://circleci.com/orbs/registry/orb/narrativescience/ghpr) [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+# CircleCI Orb: GitHub PR
 
-[View in CircleCI Orb Registry](https://circleci.com/orbs/registry/orb/narrativescience/ghpr)
+[![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/narrativescience/ghpr)](https://circleci.com/orbs/registry/orb/narrativescience/ghpr) [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
-Set of git utilities to manage GitHub Pull Requests in CI, namely simulating the result of
-merging the head branch into the PR's target base branch.
+Set of git utilities to manage GitHub Pull Requests in CI. This orb was created to address the need to simulate the result of merging the head branch into a PR's target base branch.
 
-To use, create a service GitHub user with at least Read access to your repository and set the following environment variables in a [Context](https://circleci.com/docs/2.0/contexts/) or your [Project's Environment Variables](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project):
+Additional features:
 
-* `GITHUB_USERNAME` - Username of the service user that has read/write permissions to the repo.
-* `GITHUB_PASSWORD` - Password of the service user.
-* `GITHUB_EMAIL` - Email of the service user.
+- Posting PR comments on success/failure/always
+- Sending Slack notifications to PR authors
 
 The commands in the orb will expose the following environment variables:
 
 * `GITHUB_PR_BASE_BRANCH` - The base branch for the PR.
 * `GITHUB_PR_NUMBER` - The number of the PR.
+
+## Getting Started
+
+To use this orb, there are a few environment variables to set. These can be set in a [Context](https://circleci.com/docs/2.0/contexts/) or your [Project's Environment Variables](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project).
+
+### Setting up a GitHub service user
+
+It's recommended to create a service GitHub user with at least Read access to your repository and set the following environment variables:
+
+* `GITHUB_USERNAME` - Username of the service user that has read/write permissions to the repo.
+* `GITHUB_PASSWORD` - Password of the service user.
+* `GITHUB_EMAIL` - Email of the service user.
+
+### Enabling Slack Notifications
+
+To use the Slack related orb commands, create or use an existing [workspace bot](https://slack.com/help/articles/115005265703-Create-a-bot-for-your-workspace) and set the following environment variables:
+
+* `SLACK_OAUTH_TOKEN` - [OAuth token](https://api.slack.com/docs/token-types#bot) for the Slack bot that will be used to send Slack messages.
+
+This orb uses the [email associated with commits](https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/setting-your-commit-email-address) to look up the user in a Slack workspace. Therefore, to receive notifications, committers should set their `user.email` in their `git config` to be the same email associated with their Slack account.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # CircleCI Orb: GitHub PR
 
-[![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/narrativescience/ghpr)](https://circleci.com/orbs/registry/orb/narrativescience/ghpr) [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+[![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/narrativescience/ghpr)](https://circleci.com/orbs/registry/orb/narrativescience/ghpr)
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
-Set of git utilities to manage GitHub Pull Requests in CI. This orb was created to address the need to simulate the result of merging the head branch into a PR's target base branch.
+Set of git utilities to manage GitHub Pull Requests in CI.
+This orb was created to address the need to simulate the result of merging the head branch
+into a PR's target base branch.
 
 Additional features:
 
@@ -16,11 +19,14 @@ The commands in the orb will expose the following environment variables:
 
 ## Getting Started
 
-To use this orb, there are a few environment variables to set. These can be set in a [Context](https://circleci.com/docs/2.0/contexts/) or your [Project's Environment Variables](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project).
+To use this orb, there are a few environment variables to set.
+These can be set in a [Context](https://circleci.com/docs/2.0/contexts/)
+or your [Project's Environment Variables](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project).
 
 ### Setting up a GitHub service user
 
-It's recommended to create a service GitHub user with at least Read access to your repository and set the following environment variables:
+It's recommended to create a service GitHub user with at least Read access to your
+repository and set the following environment variables:
 
 * `GITHUB_USERNAME` - Username of the service user that has read/write permissions to the repo.
 * `GITHUB_PASSWORD` - Password of the service user.
@@ -28,8 +34,14 @@ It's recommended to create a service GitHub user with at least Read access to yo
 
 ### Enabling Slack Notifications
 
-To use the Slack related orb commands, create or use an existing [workspace bot](https://slack.com/help/articles/115005265703-Create-a-bot-for-your-workspace) and set the following environment variables:
+To use the Slack related orb commands, create or use an existing
+[workspace bot](https://slack.com/help/articles/115005265703-Create-a-bot-for-your-workspace)
+and set the following environment variables:
 
-* `SLACK_OAUTH_TOKEN` - [OAuth token](https://api.slack.com/docs/token-types#bot) for the Slack bot that will be used to send Slack messages.
+* `SLACK_OAUTH_TOKEN` - [OAuth token](https://api.slack.com/docs/token-types#bot) for the Slack
+bot that will be used to send Slack messages.
 
-This orb uses the [email associated with commits](https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/setting-your-commit-email-address) to look up the user in a Slack workspace. Therefore, to receive notifications, committers should set their `user.email` in their `git config` to be the same email associated with their Slack account.
+This orb uses the [email associated with commits](https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/setting-your-commit-email-address)
+to look up the user in a Slack workspace. Therefore, to receive notifications, committers
+should set their `user.email` in their `git config` to be the same email associated with their Slack account.
+Messages show as being sent by the user associated with the `SLACK_OAUTH_TOKEN`.

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,7 +8,6 @@ examples:
     usage:
       version: 2.1
       orbs:
-        jq: circleci/jq@1.9.0
         ghpr: narrativescience/ghpr@x.y.z
       jobs:
         run-test:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -4,19 +4,20 @@ description: Bundle of utils for GitHub pull requests
 examples:
   test-pull-request:
     description: |
-      Run pull request tests on a temporary branch resulting from merging the PR's head branch into the base branch, and send a comment on test failure.
+      Run pull request tests on a temporary branch resulting from merging the PR's head branch into the base branch. Post a PR comment on test failure, but Slack the author on success.
     usage:
       version: 2.1
       orbs:
         jq: circleci/jq@1.9.0
-        ghpr: narrativescience/ghpr@0.1.0
+        ghpr: narrativescience/ghpr@x.y.z
       jobs:
         run-test:
-          docker:
-            - image: circleci/python:3.7.1
+          machine: true
           steps:
             - ghpr/build-prospective-branch
             - some-test-command
             - ghpr/post-pr-comment:
                 comment: "some message"
                 when: on_fail
+            - ghpr/slack-pr-author:
+                message: ":tada: Tests passed!"

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,14 +9,14 @@ examples:
       version: 2.1
       orbs:
         jq: circleci/jq@1.9.0
-        gh-pr: narrativescience/gh-pr@0.0.3
+        ghpr: narrativescience/ghpr@0.1.0
       jobs:
         run-test:
           docker:
             - image: circleci/python:3.7.1
           steps:
-            - gh-pr/build-prospective-branch
+            - ghpr/build-prospective-branch
             - some-test-command
-            - gh-pr/post-pr-comment:
+            - ghpr/post-pr-comment:
                 comment: "some message"
                 when: on_fail

--- a/src/commands/post-pr-comment.yml
+++ b/src/commands/post-pr-comment.yml
@@ -16,6 +16,7 @@ parameters:
 steps:
   - run:
       name: Post comment to PR
+      when: << parameters.when >>
       command: |
         GITHUB_PR_NUMBER=$(echo "$CIRCLE_PULL_REQUEST" | sed "s/.*\/pull\///")
         curl \
@@ -23,4 +24,3 @@ steps:
           -d "{\"body\": \"<< parameters.comment >>\"}" \
           --user "${GITHUB_USERNAME}:${GITHUB_PASSWORD}" \
           "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${GITHUB_PR_NUMBER}/comments"
-      when: << parameters.when >>

--- a/src/commands/slack-pr-author.yml
+++ b/src/commands/slack-pr-author.yml
@@ -74,9 +74,9 @@ steps:
         MESSAGE="*<< parameters.message >>*"
         CHANNEL=$SLACK_USER_ID
 
-        if [[ -n "<< parameters.channel >>"" ]]; then
+        if [[ -n "<< parameters.channel >>" ]]; then
           MESSAGE="$MESSAGE\n<@$SLACK_USER_ID>"
-          CHANNEL=<< parameters.channel >>
+          CHANNEL="<< parameters.channel >>"
         fi
 
         BLOCKS="[

--- a/src/commands/slack-pr-author.yml
+++ b/src/commands/slack-pr-author.yml
@@ -65,7 +65,7 @@ steps:
                     "https://slack.com/api/users.lookupByEmail")
         SLACK_USER_ID=$(echo $SLACK_USER | jq -e '.user.id' | tr -d '"')
 
-        if [[ $SLACK_USER_ID == null ]]; then
+        if [[ $SLACK_USER_ID == "null" ]]; then
           echo "No Slack user found with email $PR_AUTHOR_EMAIL"
           exit 1
         fi

--- a/src/commands/slack-pr-author.yml
+++ b/src/commands/slack-pr-author.yml
@@ -31,13 +31,13 @@ steps:
       command: |
         # Check `jq` dependency
         if ! (command -v jq >/dev/null 2>&1); then
-          echo "This command requires `jq` to be installed"
+          echo "This command requires jq to be installed"
           exit 1
         fi
 
         # Check `SLACK_OAUTH_TOKEN` is set
         if [[ -z ${SLACK_OAUTH_TOKEN+x} ]]; then
-          echo "This command requires `SLACK_OAUTH_TOKEN` to be set"
+          echo "This command requires SLACK_OAUTH_TOKEN to be set"
           exit 1
         fi
 

--- a/src/commands/slack-pr-author.yml
+++ b/src/commands/slack-pr-author.yml
@@ -57,7 +57,7 @@ steps:
         COMMIT_REQUEST_URL="$API_GITHUB/commits/$MERGE_COMMIT_SHA"
         COMMIT_RESPONSE=$(curl --user "${GITHUB_USERNAME}:${GITHUB_PASSWORD}" "$COMMIT_REQUEST_URL")
         PR_AUTHOR_EMAIL=$(echo $COMMIT_RESPONSE | jq -e '.commit.author.email' | tr -d '"')
-
+        echo "$PR_AUTHOR_EMAIL"
         SLACK_USER=$(curl -H 'Content-Type: application/x-www-form-urlencoded' \
                     -H 'Cache-Control: no-cache' \
                     -d "token=$SLACK_OAUTH_TOKEN" \
@@ -65,6 +65,7 @@ steps:
                     "https://slack.com/api/users.lookupByEmail")
         SLACK_USER_ID=$(echo $SLACK_USER | jq -e '.user.id' | tr -d '"')
 
+        echo "$SLACK_USER_ID"
         if [[ $SLACK_USER_ID == "null" ]]; then
           echo "No Slack user found with email $PR_AUTHOR_EMAIL"
           exit 1
@@ -77,6 +78,7 @@ steps:
           MESSAGE="$MESSAGE\n<@$SLACK_USER_ID>"
           CHANNEL=<< parameters.channel >>
         fi
+        echo "$MESSAGE"
 
         BLOCKS="[
           {

--- a/src/commands/slack-pr-author.yml
+++ b/src/commands/slack-pr-author.yml
@@ -57,7 +57,7 @@ steps:
         COMMIT_REQUEST_URL="$API_GITHUB/commits/$MERGE_COMMIT_SHA"
         COMMIT_RESPONSE=$(curl --user "${GITHUB_USERNAME}:${GITHUB_PASSWORD}" "$COMMIT_REQUEST_URL")
         PR_AUTHOR_EMAIL=$(echo $COMMIT_RESPONSE | jq -e '.commit.author.email' | tr -d '"')
-        echo "$PR_AUTHOR_EMAIL"
+
         SLACK_USER=$(curl -H 'Content-Type: application/x-www-form-urlencoded' \
                     -H 'Cache-Control: no-cache' \
                     -d "token=$SLACK_OAUTH_TOKEN" \
@@ -65,7 +65,7 @@ steps:
                     "https://slack.com/api/users.lookupByEmail")
         SLACK_USER_ID=$(echo $SLACK_USER | jq -e '.user.id' | tr -d '"')
 
-        echo "$SLACK_USER_ID"
+
         if [[ $SLACK_USER_ID == "null" ]]; then
           echo "No Slack user found with email $PR_AUTHOR_EMAIL"
           exit 1
@@ -74,11 +74,10 @@ steps:
         MESSAGE="*<< parameters.message >>*"
         CHANNEL=$SLACK_USER_ID
 
-        if [[ -n << parameters.channel >> ]]; then
+        if [[ -n "<< parameters.channel >>"" ]]; then
           MESSAGE="$MESSAGE\n<@$SLACK_USER_ID>"
           CHANNEL=<< parameters.channel >>
         fi
-        echo "$MESSAGE"
 
         BLOCKS="[
           {

--- a/src/commands/slack-pr-author.yml
+++ b/src/commands/slack-pr-author.yml
@@ -36,8 +36,8 @@ steps:
         fi
 
         # Check `SLACK_OAUTH_TOKEN` is set
-        if [[ -z ${var+x} ]]; then
-          echo "This command required `SLACK_OAUTH_TOKEN` to be set"
+        if [[ -z ${SLACK_OAUTH_TOKEN+x} ]]; then
+          echo "This command requires `SLACK_OAUTH_TOKEN` to be set"
           exit 1
         fi
 

--- a/src/commands/slack-pr-author.yml
+++ b/src/commands/slack-pr-author.yml
@@ -74,7 +74,7 @@ steps:
         CHANNEL=$SLACK_USER_ID
 
         if [[ -n << parameters.channel >> ]]; then
-          MESSAGE="$MESSAGE\n<@SLACK_USER_ID>"
+          MESSAGE="$MESSAGE\n<@$SLACK_USER_ID>"
           CHANNEL=<< parameters.channel >>
         fi
 

--- a/src/commands/slack-pr-author.yml
+++ b/src/commands/slack-pr-author.yml
@@ -1,0 +1,128 @@
+description: |
+  Send a Slack direct message to the PR author, or to a channel, @mentioning the PR author.
+  Requires `SLACK_OAUTH_TOKEN` to be set as an environment variable.
+
+  For more details, see https://github.com/NarrativeScience/circleci-orb-ghpr#enabling-slack-notifactions
+parameters:
+  message:
+    description: |
+      The message to send.
+      Supports Slack mrkdown syntax - https://api.slack.com/reference/surfaces/formatting#basics
+    type: string
+  when:
+    description: Condition for when the DM should be sent
+    type: enum
+    enum:
+      - on_success
+      - on_fail
+      - always
+    default: on_success
+  channel:
+    description: |
+      Optional channel to send a message to, ex. `#some-channel`.
+      If provided, will message the channel but @mention the PR author.
+      Otherwise, the message is sent to the PR author directly.
+    type: string
+    default: ""
+steps:
+  - run:
+      name: Slack PR author
+      when: << parameters.when >>
+      command: |
+        # Check `jq` dependency
+        if ! (command -v jq >/dev/null 2>&1); then
+          echo "This command requires `jq` to be installed"
+          exit 1
+        fi
+
+        # Check `SLACK_OAUTH_TOKEN` is set
+        if [[ -z ${var+x} ]]; then
+          echo "This command required `SLACK_OAUTH_TOKEN` to be set"
+          exit 1
+        fi
+
+        API_GITHUB="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+
+        GITHUB_PR_NUMBER=$(echo "$CIRCLE_PULL_REQUEST" | sed "s/.*\/pull\///")
+        PR_REQUEST_URL="$API_GITHUB/pulls/$GITHUB_PR_NUMBER"
+        PR_RESPONSE=$(curl --user "${GITHUB_USERNAME}:${GITHUB_PASSWORD}" "$PR_REQUEST_URL")
+        PR_TITLE=$(echo $PR_RESPONSE | jq -e '.title' | tr -d '"')
+
+        # Get the merge_commit_sha. This is so we can message the PR author, not the commit
+        # author who may not be the PR author.
+        MERGE_COMMIT_SHA=$(echo $PR_RESPONSE | jq -e '.merge_commit_sha' | tr -d '"')
+
+        # Sadly, PR_RESPONSE doesn't include the email associated with the MERGE_COMMIT_SHA.
+        # So we have to get that from the commit information.
+        COMMIT_REQUEST_URL="$API_GITHUB/commits/$MERGE_COMMIT_SHA"
+        COMMIT_RESPONSE=$(curl --user "${GITHUB_USERNAME}:${GITHUB_PASSWORD}" "$COMMIT_REQUEST_URL")
+        PR_AUTHOR_EMAIL=$(echo $COMMIT_RESPONSE | jq -e '.commit.author.email' | tr -d '"')
+
+        SLACK_USER=$(curl -H 'Content-Type: application/x-www-form-urlencoded' \
+                    -H 'Cache-Control: no-cache' \
+                    -d "token=$SLACK_OAUTH_TOKEN" \
+                    -d "email=$PR_AUTHOR_EMAIL" \
+                    "https://slack.com/api/users.lookupByEmail")
+        SLACK_USER_ID=$(echo $SLACK_USER | jq -e '.user.id' | tr -d '"')
+
+        if [[ $SLACK_USER_ID == null ]]; then
+          echo "No Slack user found with email $PR_AUTHOR_EMAIL"
+          exit 1
+        fi
+
+        MESSAGE="*<< parameters.message >>*"
+        CHANNEL=$SLACK_USER_ID
+
+        if [[ -n << parameters.channel >> ]]; then
+          MESSAGE="$MESSAGE\n<@SLACK_USER_ID>"
+          CHANNEL=<< parameters.chanell >>
+        fi
+
+        BLOCKS="[
+          {
+            \"type\": \"section\",
+            \"text\": {
+              \"type\": \"mrkdwn\",
+              \"text\": \"$MESSAGE\"
+            },
+            \"accessory\": {
+              \"type: \"button\",
+              \"text\": {
+                \"type\": \"plain_text\",
+                \"text\": \"Visit Job\"
+              },
+              \"url\": \"$CIRCLE_BUILD_URL\"
+            }
+          },
+          {
+            \"type\": \"section\",
+            \"text\": {
+              \"type\": \"mrkdwn\",
+              \"text\": \"*Pull Request:*\n<$CIRCLE_PULL_REQUEST|$PR_TITLE>\"
+            }
+          },
+          {
+            \"type\": \"context\",
+            \"elements\": [
+              {
+                \"type\": \"mrkdwn\",
+                \"text\": \"Project: *$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME*\"
+              },
+              {
+                \"type\": \"mrkdwn\",
+                \"text\": \"Branch: *$CIRCLE_BRANCH*\"
+              }
+            ]
+          }
+        ]"
+
+        CURL_ARGS=(
+              -X POST
+              -H 'Content-Type: application/x-www-form-urlencoded'
+              -H 'Cache-Control: no-cache'
+              -d "token=$SLACK_OAUTH_TOKEN"
+              -d 'as_user=true'
+              -d "channel=$CHANNEL"
+              -d "blocks=$BLOCKS"
+            )
+        curl "${CURL_ARGS[@]}" "https://slack.com/api/chat.postMessage"

--- a/src/commands/slack-pr-author.yml
+++ b/src/commands/slack-pr-author.yml
@@ -87,7 +87,7 @@ steps:
               \"text\": \"$MESSAGE\"
             },
             \"accessory\": {
-              \"type: \"button\",
+              \"type\": \"button\",
               \"text\": {
                 \"type\": \"plain_text\",
                 \"text\": \"Visit Job\"
@@ -99,7 +99,7 @@ steps:
             \"type\": \"section\",
             \"text\": {
               \"type\": \"mrkdwn\",
-              \"text\": \"*Pull Request:*\n<$CIRCLE_PULL_REQUEST|$PR_TITLE>\"
+              \"text\": \"*Pull Request:* <$CIRCLE_PULL_REQUEST|$PR_TITLE>\"
             }
           },
           {

--- a/src/commands/slack-pr-author.yml
+++ b/src/commands/slack-pr-author.yml
@@ -65,7 +65,6 @@ steps:
                     "https://slack.com/api/users.lookupByEmail")
         SLACK_USER_ID=$(echo $SLACK_USER | jq -e '.user.id' | tr -d '"')
 
-
         if [[ $SLACK_USER_ID == "null" ]]; then
           echo "No Slack user found with email $PR_AUTHOR_EMAIL"
           exit 1

--- a/src/commands/slack-pr-author.yml
+++ b/src/commands/slack-pr-author.yml
@@ -75,7 +75,7 @@ steps:
 
         if [[ -n << parameters.channel >> ]]; then
           MESSAGE="$MESSAGE\n<@SLACK_USER_ID>"
-          CHANNEL=<< parameters.chanell >>
+          CHANNEL=<< parameters.channel >>
         fi
 
         BLOCKS="[


### PR DESCRIPTION
### Changes
Adds a `slack-pr-author` command. From the command description:
> Send a Slack direct message to the PR author, or to a channel, @mentioning the PR author.
  Requires `SLACK_OAUTH_TOKEN` to be set as an environment variable.

Example.
<img width="615" alt="Screen Shot 2020-03-29 at 01 21 02" src="https://user-images.githubusercontent.com/29710511/77842739-9260c700-715b-11ea-8c67-0992340afbac.png">

We'll need to update our CircleCI bot user to have the `users:read.email` permission if we want to use the command in our OS projects.