### PR TITLE
Don't block if no Slack user found

### DIFF
--- a/src/commands/slack-pr-author.yml
+++ b/src/commands/slack-pr-author.yml
@@ -67,7 +67,8 @@ steps:
 
         if [[ $SLACK_USER_ID == "null" ]]; then
           echo "No Slack user found with email $PR_AUTHOR_EMAIL"
-          exit 1
+          # Don't fail the command. This shouldn't be a blocker.
+          exit 0
         fi
 
         MESSAGE="*<< parameters.message >>*"


### PR DESCRIPTION
Sending a Slack notification is a nice-to-have. If no Slack user is found for a commit's associated email address, it shouldn't block PRs from passing. This change has the added benefit of making notifications opt-in.