### PR TITLE
Custom commit message on merge commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   # dev version needs to be manually deployed to accurately test commit changes.
   # Once deployed, update <alpha> to reflect the version deployed.
-  ghpr: narrativescience/ghpr@dev:alpha
+  ghpr: narrativescience/ghpr@dev:1.1.2
 
 commands:
   pack-validate:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
     machine: true
     steps:
       - ghpr/build-prospective-branch
+          force: true
       - ghpr/slack-pr-author:
           message: ":tada: Tests passed!"
           get_slack_user_by: meseeks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
   test:
     machine: true
     steps:
-      - ghpr/build-prospective-branch
+      - ghpr/build-prospective-branch:
           force: true
       - ghpr/slack-pr-author:
           message: ":tada: Tests passed!"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   # dev version needs to be manually deployed to accurately test commit changes.
   # Once deployed, update <alpha> to reflect the version deployed.
-  ghpr: narrativescience/ghpr@dev:1.1.2
+  ghpr: narrativescience/ghpr@dev:1.1.3
 
 commands:
   pack-validate:

--- a/src/commands/build-prospective-branch.yml
+++ b/src/commands/build-prospective-branch.yml
@@ -17,7 +17,9 @@ steps:
         set +e
         git config --global user.email "$GITHUB_EMAIL"
         git config --global user.name "$GITHUB_USERNAME"
-        git fetch && git merge "origin/$GITHUB_PR_BASE_BRANCH" --no-edit
+        # Merge the branch with no commit and then create a custom commit message contianing the original commit message.
+        git fetch && git merge "origin/$GITHUB_PR_BASE_BRANCH" --no-commit
+        git commit -am "Merging ${GITHUB_PR_BASE_BRANCH} into ${CIRCLE_BRANCH}. ${GITHUB_PR_COMMIT_MESSAGE}"
         if [[ $? -ne 0 && << parameters.force >> == false ]]; then
           echo "Failed to merge $GITHUB_PR_BASE_BRANCH into $CIRCLE_BRANCH"
           exit 1


### PR DESCRIPTION
# Overview
There is a case where downstream commands using commands such as `git log -1` look for a specific syntax expected in the commit message. This ensures that the commit message is preserved along with the merge commit. 