### PR TITLE
Allow parameterized get_commit_message in build prospective branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   # dev version needs to be manually deployed to accurately test commit changes.
   # Once deployed, update <alpha> to reflect the version deployed.
-  ghpr: narrativescience/ghpr@dev:1.1.3
+  ghpr: narrativescience/ghpr@dev:1.1.4
 
 commands:
   pack-validate:

--- a/src/commands/build-prospective-branch.yml
+++ b/src/commands/build-prospective-branch.yml
@@ -8,9 +8,14 @@ parameters:
       By default, this is disabled, to allow failing when a merge conflict occurs.
     type: boolean
     default: false
+  get_commit_message:
+    description: If true, also sets GITHUB_PR_COMMIT_MESSAGE. This requires an additional API call.
+    type: boolean
+    default: false
 steps:
   - checkout
-  - get-pr-info
+  - get-pr-info:
+      get_commit_message: << parameters.get_commit_message >>
   - run:
       name: Build prospective merge branch
       command: |


### PR DESCRIPTION
# Overview
Allows for the build prospective branch command to trigger a get_commit_message API call.