### PR TITLE
BUG FIX: Fixing parameter expansion

### DIFF
--- a/src/commands/get-pr-info.yml
+++ b/src/commands/get-pr-info.yml
@@ -83,5 +83,5 @@ steps:
         COMMIT_RESPONSE=$(curl -H "Authorization: token $GITHUB_TOKEN" "$COMMIT_REQUEST_URL")
         PR_COMMIT_MESSAGE=$(echo $COMMIT_RESPONSE | jq -e '.commit.message' | tr -d '"')
         echo "PR_COMMIT_MESSAGE: $PR_COMMIT_MESSAGE"
-        echo "export GITHUB_PR_COMMIT_MESSAGE='${PR_COMMIT_MESSAGE/"'"/}'" >> $BASH_ENV
+        echo "export GITHUB_PR_COMMIT_MESSAGE='${PR_COMMIT_MESSAGE//\'/}'" >> $BASH_ENV
         <</ parameters.get_commit_message >>


### PR DESCRIPTION
# Overview
We never hit this edge case before because no one was using this portion of the get-pr-info job. I started using this and it was hit today when someone had `'` in the commit message. Fixing the parameter expansion to properly escape this char and remove it.